### PR TITLE
Spartacus shortwave optimizations + avoiding double prec. in two-stream kernels 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *_out.nc
 config_*.nam
 *_sza.nc
+test/ifs/tmp/

--- a/driver/test_spartacus_math.F90
+++ b/driver/test_spartacus_math.F90
@@ -89,7 +89,7 @@ program test_spartacus_math
 
   if (m == 2) then
 
-    call fast_expm_exchange(n,n,aa,bb,A)
+    call fast_expm_exchange(n,aa,bb,A)
     
     write(*,*) 'fast_expm(A) = '
     do j = 1,m
@@ -111,7 +111,7 @@ program test_spartacus_math
 
     ! Test zeros lead to identity matrix
     aa = 0.0_jprb
-    call fast_expm_exchange(n,n,aa,aa,A)
+    call fast_expm_exchange(n,aa,aa,A)
     
     write(*,*) 'expm(zeros) = '
     do j = 1,m
@@ -120,7 +120,7 @@ program test_spartacus_math
 
   else 
     
-    call fast_expm_exchange(n,n,aa,bb,cc,dd,A)
+    call fast_expm_exchange(n,aa,bb,cc,dd,A)
     
     write(*,*) 'fast_expm(A) = '
     do j = 1,m
@@ -145,7 +145,7 @@ program test_spartacus_math
 
     ! Test zeros lead to identity matrix
     aa = 0.0_jprb
-    call fast_expm_exchange(n,n,aa,aa,aa,aa,A)
+    call fast_expm_exchange(n,aa,aa,aa,aa,A)
     
     write(*,*) 'expm(zeros) = '
     do j = 1,m

--- a/radiation/radiation_matrix.F90
+++ b/radiation/radiation_matrix.F90
@@ -13,7 +13,9 @@
 ! Email:   r.j.hogan@ecmwf.int
 !
 ! Modifications
-!   2018-10-15  R. Hogan  Added fast_expm_exchange_[23]
+!   2018-10-15  R. Hogan    Added fast_expm_exchange_[23]
+!   2020-12-xx  P. Ukkonen  Added an optimized expm routine for shortwave when nreg=3,
+!                           and related kernels
 !
 ! This module provides the neccessary mathematical functions for the
 ! SPARTACUS radiation scheme: matrix multiplication, matrix solvers
@@ -77,6 +79,7 @@ contains
 
     if (lhook) call dr_hook('radiation_matrix:mat_x_vec',0,hook_handle)
 
+
     if (present(do_top_left_only_in)) then
       do_top_left_only = do_top_left_only_in
     else
@@ -101,6 +104,25 @@ contains
 
   end function mat_x_vec
 
+  pure function mat_x_vec_3(n,A,b)
+
+    integer,    intent(in)                   :: n
+    real(jprb), intent(in), dimension(n,3,3) :: A
+    real(jprb), intent(in), dimension(n,3)   :: b
+    real(jprb), dimension(n,3):: mat_x_vec_3
+    integer :: j1
+
+    ! Array-wise assignment
+    mat_x_vec_3 = 0.0_jprb
+
+    do j1 = 1,3
+        mat_x_vec_3(:,j1) = mat_x_vec_3(:,j1) + A(:,j1,1)*b(:,1)
+        mat_x_vec_3(:,j1) = mat_x_vec_3(:,j1) + A(:,j1,2)*b(:,2)
+        mat_x_vec_3(:,j1) = mat_x_vec_3(:,j1) + A(:,j1,3)*b(:,3)
+    end do
+
+  end function mat_x_vec_3
+
 
   !---------------------------------------------------------------------
   ! Treat A as an m-by-m square matrix and b as n m-element vectors
@@ -117,7 +139,7 @@ contains
 
     integer    :: j1, j2
     real(jprb) :: hook_handle
-
+    
     if (lhook) call dr_hook('radiation_matrix:single_mat_x_vec',0,hook_handle)
 
     ! Array-wise assignment
@@ -214,7 +236,40 @@ contains
 
   end function mat_x_mat
 
+  pure function mat_x_mat_dense(n,m,A,B)
 
+    integer,    intent(in)                      :: n, m
+    real(jprb), intent(in), dimension(n,m,m)    :: A, B
+
+    real(jprb),             dimension(n,m,m) :: mat_x_mat_dense
+    integer    :: j1, j2, j3
+
+    if (m==3) then
+      do j2 = 1,m
+        do j1 = 1,m
+          mat_x_mat_dense(:,j1,j2) = A(:,j1,1)*B(:,1,j2) &
+          &  + A(:,j1,2)*B(:,2,j2) + A(:,j1,3)*B(:,3,j2) 
+        end do
+      end do
+
+    else 
+  
+      ! Array-wise assignment
+      mat_x_mat_dense = 0.0_jprb
+
+      do j2 = 1,m
+        do j1 = 1,m
+          do j3 = 1,m
+            mat_x_mat_dense(:,j1,j2) = mat_x_mat_dense(:,j1,j2) &
+                  &                  + A(:,j1,j3)*B(:,j3,j2)
+          end do
+        end do
+      end do
+
+    end if
+
+  end function mat_x_mat_dense
+ 
   !---------------------------------------------------------------------
   ! Treat A as an m-by-m matrix and B as n m-by-m square matrices
   ! (with the n dimension varying fastest) and perform matrix
@@ -398,6 +453,35 @@ contains
 
   end function repeated_square
 
+  pure subroutine repeated_square_sw_9(nrepeat,A,B)
+    integer,    intent(in)            :: nrepeat
+    real(jprb), intent(inout)         :: A(9,9)
+    real(jprb), intent(out)           :: B(9,9)
+
+    integer :: j1, j2, j3, j4
+
+    do j4 = 1,nrepeat
+      B = 0.0_jprb
+      ! Do the top-left (C, D, F & G)
+      do j2 = 1,6
+          do j3 = 1,6
+            B(1:6,j2) = B(1:6,j2) + A(1:6,j3)*A(j3,j2)
+          end do
+      end do
+      do j2 = 7, 9
+          do j3 = 1,9 ! Do the top-right (E & H)
+            B(1:6,j2) = B(1:6,j2) + A(1:6,j3)*A(j3,j2)
+          end do
+          do j3 = 7,9  ! Do the bottom-right (I)
+            B(7:9,j2) = B(7:9,j2) + A(7:9,j3)*A(j3,j2)
+          end do
+      end do
+      if (j4 < nrepeat) then
+          A = B
+      end if
+    end do
+  end subroutine repeated_square_sw_9
+
 
   ! --- SOLVE LINEAR EQUATIONS ---
 
@@ -539,15 +623,15 @@ contains
   ! Return X = B A^-1 = (A^-T B)^T optimized for 3x3 matrices, where B
   ! is a diagonal matrix, using LU factorization and substitution with
   ! no pivoting.
-  pure subroutine diag_mat_right_divide_3(n,iend,A,B,X)
-    integer,    intent(in)  :: n, iend
-    real(jprb), intent(in)  :: A(iend,3,3)
-    real(jprb), intent(in)  :: B(iend,3)
+  pure subroutine diag_mat_right_divide_3(n,A,B,X)
+    integer,    intent(in)  :: n
+    real(jprb), intent(in)  :: A(n,3,3)
+    real(jprb), intent(in)  :: B(n,3)
     real(jprb), intent(out) :: X(n,3,3)
 
-    real(jprb), dimension(iend) :: L21, L31, L32
-    real(jprb), dimension(iend) :: U22, U23, U33
-    real(jprb), dimension(iend) :: y2, y3
+    real(jprb), dimension(n) :: L21, L31, L32
+    real(jprb), dimension(n) :: U22, U23, U33
+    real(jprb), dimension(n) :: y2, y3
 
     integer :: j
 
@@ -556,38 +640,38 @@ contains
     !       ( 1        )   (U11 U12 U13)
     ! A^T = (L21  1    ) * (    U22 U23)
     !       (L31 L32  1)   (        U33)
-    L21 = A(1:iend,1,2) / A(1:iend,1,1)
-    L31 = A(1:iend,1,3) / A(1:iend,1,1)
-    U22 = A(1:iend,2,2) - L21*A(1:iend,2,1)
-    U23 = A(1:iend,3,2) - L21*A(1:iend,3,1)
-    L32 =(A(1:iend,2,3) - L31*A(1:iend,2,1)) / U22
-    U33 = A(1:iend,3,3) - L31*A(1:iend,3,1) - L32*U23
+    L21 = A(:,1,2) / A(:,1,1)
+    L31 = A(:,1,3) / A(:,1,1)
+    U22 = A(:,2,2) - L21*A(:,2,1)
+    U23 = A(:,3,2) - L21*A(:,3,1)
+    L32 =(A(:,2,3) - L31*A(:,2,1)) / U22
+    U33 = A(:,3,3) - L31*A(:,3,1) - L32*U23
 
     ! Solve X(1,:) = A^-T ( B(1) )
     !                     (  0   )
     !                     (  0   )
     ! Solve Ly = B(:,:,j) by forward substitution
     ! y1 = B(:,1)
-    y2 = - L21*B(1:iend,1)
-    y3 = - L31*B(1:iend,1) - L32*y2
+    y2 = - L21*B(:,1)
+    y3 = - L31*B(:,1) - L32*y2
     ! Solve UX(:,:,j) = y by back substitution
-    X(1:iend,1,3) = y3 / U33
-    X(1:iend,1,2) = (y2 - U23*X(1:iend,1,3)) / U22
-    X(1:iend,1,1) = (B(1:iend,1) - A(1:iend,2,1)*X(1:iend,1,2) &
-         &          - A(1:iend,3,1)*X(1:iend,1,3)) / A(1:iend,1,1)
+    X(:,1,3) = y3 / U33
+    X(:,1,2) = (y2 - U23*X(:,1,3)) / U22
+    X(:,1,1) = (B(:,1) - A(:,2,1)*X(:,1,2) &
+         &          - A(:,3,1)*X(:,1,3)) / A(:,1,1)
 
     ! Solve X(2,:) = A^-T (  0   )
     !                     ( B(2) )
     !                     (  0   )
     ! Solve Ly = B(:,:,j) by forward substitution
     ! y1 = 0
-    ! y2 = B(1:iend,2)
-    y3 = - L32*B(1:iend,2)
+    ! y2 = B(:,2)
+    y3 = - L32*B(:,2)
     ! Solve UX(:,:,j) = y by back substitution
-    X(1:iend,2,3) = y3 / U33
-    X(1:iend,2,2) = (B(1:iend,2) - U23*X(1:iend,2,3)) / U22
-    X(1:iend,2,1) = (-A(1:iend,2,1)*X(1:iend,2,2) &
-         &           -A(1:iend,3,1)*X(1:iend,2,3)) / A(1:iend,1,1)
+    X(:,2,3) = y3 / U33
+    X(:,2,2) = (B(:,2) - U23*X(:,2,3)) / U22
+    X(:,2,1) = (-A(:,2,1)*X(:,2,2) &
+         &           -A(:,3,1)*X(:,2,3)) / A(:,1,1)
 
     ! Solve X(3,:) = A^-T (  0   )
     !                     (  0   )
@@ -595,12 +679,12 @@ contains
     ! Solve Ly = B(:,:,j) by forward substitution
     ! y1 = 0
     ! y2 = 0
-    ! y3 = B(1:iend,3)
+    ! y3 = B(:,3)
     ! Solve UX(:,:,j) = y by back substitution
-    X(1:iend,3,3) = B(1:iend,3) / U33
-    X(1:iend,3,2) = -U23*X(1:iend,3,3) / U22
-    X(1:iend,3,1) = (-A(1:iend,2,1)*X(1:iend,3,2) &
-         &          - A(1:iend,3,1)*X(1:iend,3,3)) / A(1:iend,1,1)
+    X(:,3,3) = B(:,3) / U33
+    X(:,3,2) = -U23*X(:,3,3) / U22
+    X(:,3,1) = (-A(:,2,1)*X(:,3,2) &
+         &          - A(:,3,1)*X(:,3,3)) / A(:,1,1)
 
   end subroutine diag_mat_right_divide_3
 
@@ -765,9 +849,267 @@ contains
 
   end function solve_mat
 
+  pure subroutine mat_square_sw(m,iend,A,C)
+
+    integer,    intent(in)                        :: m,iend
+    real(jprb), intent(in),  dimension(iend,m,m)  :: A
+    real(jprb), intent(out), dimension(iend,m,m)  :: C
+    integer    :: j1, j2, j3
+    integer    :: mblock, m2block
+
+    ! Array-wise assignment
+    ! C = 0.0_jprb
+
+    ! Matrix has a sparsity pattern
+    !     (C D E)
+    ! A = (F G H)
+    !     (0 0 I)
+
+    mblock = m/3       ! 
+    m2block = 2*mblock ! 
+
+    ! Do the top-left (C, D, F, G)
+    do j2 = 1,m2block  !    1,6 
+      C(:,:,j2) = 0.0_jprb
+      do j1 = 1,m2block !   1,6
+        do j3 = 1,m2block ! 1,6
+          C(:,j1,j2) = C(:,j1,j2) + A(:,j1,j3)*A(:,j3,j2)
+        end do
+        ! using sum was faster on GCC+AMD Zen platform but not on Intel
+        ! C(:,j1,j2) = sum(A(:,j1,1:m2block)*A(:,1:m2block,j2),2)
+      end do
+    end do
+
+    do j2 = m2block+1,m  ! 7,9
+      C(:,:,j2) = 0.0_jprb
+      ! Do the top-right (E & H)
+      do j1 = 1,m2block  ! 1,6
+        do j3 = 1,m      ! 1,9
+          C(:,j1,j2) = C(:,j1,j2) + A(:,j1,j3)*A(:,j3,j2)
+        end do
+      end do
+
+      ! Do the bottom-right (I)
+      do j1 = m2block+1,m   ! 7,9
+        do j3 = m2block+1,m ! 7,9
+          C(:,j1,j2) =  C(:,j1,j2) + A(:,j1,j3)*A(:,j3,j2)
+        end do
+      end do
+    end do
+
+  end subroutine mat_square_sw
+
+  pure subroutine mat_square_sw_9(iend,A,C)
+
+    integer,    intent(in)                        :: iend
+    real(jprb), intent(in),  dimension(iend,9,9)  :: A
+    real(jprb), intent(out), dimension(iend,9,9)  :: C
+    integer    :: j1, j2, j3, jg
+
+    ! First input matrix has pattern
+
+    !     (C    D     E)
+    ! A = (F=-D G=-C  H)
+    !     (0    0     I)
+
+    ! As a result, output and subsequent input matrices have pattern
+    
+    !     (C    D    E)
+    ! A = (F=D  G=C  H)
+    !     (0    0    I)
+
+    do j2 = 1,3  !    1,3 
+      do j1 = 1,6 !   1,6   C, F
+        ! do j3 = 1,6 ! 1,6
+        !   C(:,j1,j2) = C(:,j1,j2) + A(:,j1,j3)*A(:,j3,j2)
+        ! end do
+        ! Further speedup: flatten last loop, only one write SIMD instruction
+        C(:,j1,j2) = A(:,j1,1)*A(:,1,j2) + A(:,j1,2)*A(:,2,j2) &
+        &          + A(:,j1,3)*A(:,3,j2) + A(:,j1,4)*A(:,4,j2) &
+        &          + A(:,j1,5)*A(:,5,j2) + A(:,j1,6)*A(:,6,j2)
+      end do
+    end do
+    ! D,G
+    C(:,1:3,4:6) = C(:,4:6,1:3) ! D = F
+    C(:,4:6,4:6) = C(:,1:3,1:3) ! G = C
+
+    ! Lower left corner with zeros
+    C(:,7:9,1:6) = 0.0_jprb
+
+    do j2 = 7,9  ! 7,9
+      ! Do the top-right (E & H)
+      do j1 = 1,6  ! 1,6
+        C(:,j1,j2) = A(:,j1,1)*A(:,1,j2) + A(:,j1,2)*A(:,2,j2) &
+        &          + A(:,j1,3)*A(:,3,j2) + A(:,j1,4)*A(:,4,j2) &
+        &          + A(:,j1,5)*A(:,5,j2) + A(:,j1,6)*A(:,6,j2) &
+        &          + A(:,j1,7)*A(:,7,j2) + A(:,j1,8)*A(:,8,j2) &
+        &          + A(:,j1,9)*A(:,9,j2)
+      end do
+      ! Do the bottom-right (I)
+      do j1 = 7,9   ! 7,9
+        C(:,j1,j2) = A(:,j1,7)*A(:,7,j2) + A(:,j1,8)*A(:,8,j2) + A(:,j1,9)*A(:,9,j2)
+      end do
+    end do
+
+  end subroutine mat_square_sw_9
+
+  pure subroutine mat_x_mat_sw_9(iend,A,B,C)
+
+    integer,    intent(in)                      :: iend
+    real(jprb), intent(in), dimension(iend,9,9) :: A, B
+    real(jprb), intent(out),dimension(iend,9,9) :: C
+    integer    :: j1, j2, j3
+
+    do j2 = 1,3  !    1,3 
+      do j1 = 1,6 !   1,6   C, F
+        C(:,j1,j2) = A(:,j1,1)*B(:,1,j2) + A(:,j1,2)*B(:,2,j2) &
+        &          + A(:,j1,3)*B(:,3,j2) + A(:,j1,4)*B(:,4,j2) &
+        &          + A(:,j1,5)*B(:,5,j2) + A(:,j1,6)*B(:,6,j2)
+      end do
+    end do
+    ! D,G
+    C(:,1:3,4:6) = C(:,4:6,1:3) ! D = F
+    C(:,4:6,4:6) = C(:,1:3,1:3) ! G = C
+
+    ! Lower left corner with zeros
+    C(:,7:9,1:6) = 0.0_jprb
+
+    do j2 = 7,9  ! 7,9
+      ! Do the top-right (E & H)
+      do j1 = 1,6  ! 1,6
+        C(:,j1,j2) = A(:,j1,1)*B(:,1,j2) + A(:,j1,2)*B(:,2,j2) &
+        &          + A(:,j1,3)*B(:,3,j2) + A(:,j1,4)*B(:,4,j2) &
+        &          + A(:,j1,5)*B(:,5,j2) + A(:,j1,6)*B(:,6,j2) &
+        &          + A(:,j1,7)*B(:,7,j2) + A(:,j1,8)*B(:,8,j2) &
+        &          + A(:,j1,9)*B(:,9,j2)
+      end do
+
+      ! Do the bottom-right (I)
+      do j1 = 7,9   ! 7,9
+        C(:,j1,j2) = A(:,j1,7)*B(:,7,j2) + A(:,j1,8)*B(:,8,j2) + A(:,j1,9)*B(:,9,j2)
+      end do
+    end do
+
+  end subroutine mat_x_mat_sw_9
+
+  !---------------------------------------------------------------------
+  ! Solve AX=B, where A, X and B consist of iend m-by-m matrices
+  ! Overwrite B with X. A is corrupted
+  pure subroutine solve_mat_sw_9(iend,A,B)
+    integer,    intent(in) :: iend
+    real(jprb), intent(inout) :: A(iend,9,9) ! A=LU is corrupted
+    real(jprb), intent(inout) :: B(iend,9,9) ! X = B, both input and output
+    ! real(jprb), intent(out):: X(iend,m,m)
+
+    integer :: j,j1, j2, j3, mblock, m2block,m
+    real(jprb) :: s(iend)
+
+    !     (C   D  E)
+    ! A = (-D -C  H)
+    !     (0   0  I)
+
+    m = 9
+    mblock = 3 !m/3       
+    m2block = 6 !2*mblock 
+
+    ! factorization of A into LU
+
+    ! First do columns 1-6, for which only rows 1-6 have non-negative entries
+    do j2 = 1, m2block
+      do j1 = 1, j2-1
+        do j3 = 1, j1-1
+          A(:,j1,j2) = A(:,j1,j2)- A(:,j1,j3) * A(:,j3,j2)
+        end do
+      end do
+      do j1 = j2, m2block
+        do j3 = 1, j2-1
+          A(:,j1,j2) = A(:,j1,j2) - A(:,j1,j3) * A(:,j3,j2)
+        end do
+      end do
+      s = 1.0_jprb / A(:,j2,j2)
+      do j1 = j2+1, m2block
+        A(:,j1,j2) = A(:,j1,j2) * s
+      end do
+    end do
+
+    ! Remaining columns
+    do j2 = m2block+1, m
+      do j1 = 1, j2-1
+        do j3 = 1, j1-1
+          A(:,j1,j2) = A(:,j1,j2) - A(:,j1,j3) * A(:,j3,j2)
+        end do
+      end do
+      do j1 = j2, m
+        do j3 = 1, j2-1
+          A(:,j1,j2)= A(:,j1,j2) - A(:,j1,j3) * A(:,j3,j2)
+        end do
+      end do
+      if (j2 /= m) then
+        s = 1.0_jprb / A(:,j2,j2)
+        do j1 = j2+1, m
+          A(:,j1,j2) = A(:,j1,j2) * s
+        end do
+      end if
+    end do
+
+    !---------------------------------------------------------------------
+    ! Treat LU as an LU-factorization of an original matrix A, and
+    ! return x where Ax=b. LU consists of n m-by-m matrices and b as n
+    ! m-element vectors.
+    ! Here B is both input b and output x, and A has been LU factorized, combining L and U
+    ! into one matrix where the diagonal is the diagonal of U (L has ones in the diagonal)
+
+    ! A and B both have following structure:
+    !     (C   D  E)
+    !     (F   G  H)
+    !     (0   0  I)
+
+    ! Separate j3 (columns) into two regions to avoid redundant operations with zero
+    do j3 = 1,m2block ! in this region B(:,7:9),A(:,7:9) are 0
+      ! First solve Ly=b
+      do j2 = 2, m2block
+        do j1 = 1, j2-1
+          B(:,j2,j3) = B(:,j2,j3) - B(:,j1,j3)*A(:,j2,j1)
+        end do
+        ! No division because diagonal of L is unity
+      end do
+      ! Now solve Ux=y
+      do j2 = m2block, 1, -1
+        do j1 = j2+1, m2block
+          B(:,j2,j3) = ( B(:,j2,j3) - B(:,j1,j3)*A(:,j2,j1) )
+        end do
+        B(:,j2,j3) = B(:,j2,j3) / A(:,j2,j2) ! Divide by diagonal of A=U
+      end do
+    end do
+
+    do j3 = m2block+1,m ! columns 7-9: here B has nonzero values for all rows, but A doesn't 
+      ! First solve Ly=b
+      ! do j2 = 2, m
+      do j2 = 2, m2block 
+        do j1 = 1, j2-1
+          B(:,j2,j3) = B(:,j2,j3) - B(:,j1,j3)*A(:,j2,j1)
+        end do
+        ! No division because diagonal of L is unity
+      end do
+      ! When j2 = 7, the A terms are all 0, because A(7,1:6)=0
+      ! when j2 = 8, only the last j1 has nonzero A
+      ! When j2 = 9, two last j1 are nonzero
+      B(:,8,j3) = B(:,8,j3) - B(:,7,j3)*A(:,8,7)   ! j2 = 8
+      B(:,9,j3) = B(:,9,j3) - B(:,8,j3)*A(:,9,8) - B(:,7,j3)*A(:,9,7) ! j2 = 9
+
+      ! Now solve Ux=y
+      do j2 = m, 1, -1
+        do j1 = j2+1, m
+          B(:,j2,j3) = B(:,j2,j3) - B(:,j1,j3)*A(:,j2,j1)
+        end do
+        B(:,j2,j3) = B(:,j2,j3) / A(:,j2,j2) ! Divide by diagonal of A=U
+      end do
+    end do
+
+  end subroutine solve_mat_sw_9
+
 
   ! --- MATRIX EXPONENTIATION ---
-
   !---------------------------------------------------------------------
   ! Perform matrix exponential of n m-by-m matrices stored in A (where
   ! index n varies fastest) using the Higham scaling and squaring
@@ -876,6 +1218,123 @@ contains
 
   end subroutine expm
 
+  !---------------------------------------------------------------------
+  ! Like expm, but optimized for the shortwave, which has
+  ! a special matrix structure with zeros and repeated elements. 
+  ! Further assumes nreg = 3  =>  m = 9
+  subroutine expm_opt(iend,A)
+
+    use yomhook, only : lhook, dr_hook
+
+    integer,    intent(in)      :: iend
+    real(jprb), intent(inout)   :: A(iend,9,9)
+
+    real(jprb), parameter :: theta(3) = (/4.258730016922831e-01_jprb, &
+         &                                1.880152677804762e+00_jprb, &
+         &                                3.925724783138660e+00_jprb/) 
+    real(jprb), parameter :: c(8) = (/17297280.0_jprb, 8648640.0_jprb, &
+         &                1995840.0_jprb, 277200.0_jprb, 25200.0_jprb, &
+         &                1512.0_jprb, 56.0_jprb, 1.0_jprb/)
+
+    real(jprb), dimension(iend,9,9) :: A2, A4, A6
+    real(jprb), dimension(iend,9,9) :: U, V
+    real(jprb), dimension(9,9)      :: temp_in, temp_out
+    real(jprb) :: normA(iend), sum_column(iend)
+
+    integer    :: j1, j2, j3, j4,minexpo, nrepeat
+    real(jprb) :: frac(iend)
+    integer    :: expo(iend)
+    real(jprb) :: scaling(iend)
+    real(jprb) :: hook_handle
+
+    if (lhook) call dr_hook('radiation_matrix:expm_opt',0,hook_handle)
+
+    normA = 0.0_jprb
+
+    ! Compute the 1-norms of A
+    do j3 = 1,9
+      sum_column(:) = 0.0_jprb
+      do j2 = 1,9
+        do j1 = 1,iend
+          sum_column(j1) = sum_column(j1) + abs(A(j1,j2,j3))
+        end do
+      end do
+      do j1 = 1,iend
+        if (sum_column(j1) > normA(j1)) then
+          normA(j1) = sum_column(j1)
+        end if
+      end do
+    end do
+
+    frac = fraction(normA/theta(3))
+    expo = exponent(normA/theta(3))
+    where (frac == 0.5_jprb)
+      expo = expo - 1
+    end where
+
+    where (expo < 0)
+      expo = 0
+    end where
+    
+    minexpo = minval(expo)
+    ! Scale the input matrices by a power of 2
+    scaling = 2.0_jprb**(-expo)
+    do j3 = 1,9
+      do j2 = 1,9
+        A(:,j2,j3) = A(:,j2,j3) * scaling
+      end do
+    end do
+    ! Pade approximant of degree 7
+    call mat_square_sw_9(iend,A,A2)    ! These matrices have zeroes in the lower left corner AND repeated elements
+    call mat_square_sw_9(iend,A2,A4)
+
+    call mat_x_mat_sw_9(iend,A2,A4,A6) ! These matrices have zeroes in the lower left corner AND repeated elements
+
+    V = c(8)*A6 + c(6)*A4 + c(4)*A2
+    do j3 = 1,9
+      V(:,j3,j3) = V(:,j3,j3) + c(2)
+    end do
+
+    U = mat_x_mat(iend,iend,9,A,V,IMatrixPatternShortwave)
+
+    V = c(7)*A6 + c(5)*A4 + c(3)*A2
+    ! Add a multiple of the identity matrix
+    do j3 = 1,9
+      V(:,j3,j3) = V(:,j3,j3) + c(1)
+    end do
+
+    V = V-U
+    A = 2.0_jprb*U
+
+    ! A = solve_mat(n,iend,m,V,U)
+    call solve_mat_sw_9(iend,V,A)
+
+    ! Add the identity matrix
+    do j3 = 1,9
+      A(:,j3,j3) = A(:,j3,j3) + 1.0_jprb
+    end do
+
+    ! Loop through the matrices    
+    ! To improve efficiency, square all matrices with the minimum expo first, and then square individual matrices as needed
+    do j1 = 1,minexpo
+      call mat_square_sw(9,iend,A,A2)
+      A = A2
+    end do
+
+    do j1 = 1,iend
+      if (expo(j1) > minexpo) then
+        nrepeat = expo(j1)-minexpo
+        !Square matrix nrepeat times 
+        temp_in =  A(j1,:,:)
+        call repeated_square_sw_9(nrepeat,temp_in,temp_out)
+        A(j1,:,:) = temp_out
+      end if
+    end do
+ 
+    if (lhook) call dr_hook('radiation_matrix:expm_opt',1,hook_handle)
+
+  end subroutine expm_opt
+
 
   !---------------------------------------------------------------------
   ! Return the matrix exponential of n 2x2 matrices representing
@@ -885,27 +1344,27 @@ contains
   !   ( a  -b)
   ! and a and b are assumed to be positive or zero.  The solution uses
   ! Putzer's algorithm - see the appendix of Hogan et al. (GMD 2018)
-  subroutine fast_expm_exchange_2(n,iend,a,b,R)
+  subroutine fast_expm_exchange_2(n,a,b,R)
 
     use yomhook, only : lhook, dr_hook
 
-    integer,                      intent(in)  :: n, iend
+    integer,                      intent(in)  :: n
     real(jprb), dimension(n),     intent(in)  :: a, b
     real(jprb), dimension(n,2,2), intent(out) :: R
 
-    real(jprb), dimension(iend) :: factor
+    real(jprb), dimension(n) :: factor
 
     real(jprb) :: hook_handle
 
     if (lhook) call dr_hook('radiation_matrix:fast_expm_exchange_2',0,hook_handle)
 
     ! Security to ensure that if a==b==0 then the identity matrix is returned
-    factor = (1.0_jprb - exp(-(a(1:iend)+b(1:iend))))/max(1.0e-12_jprb,a(1:iend)+b(1:iend))
+    factor = (1.0_jprb - exp(-(a(:)+b(:))))/max(1.0e-12_jprb,a(:)+b(:))
 
-    R(1:iend,1,1) = 1.0_jprb - factor*a(1:iend)
-    R(1:iend,2,1) = factor*a(1:iend)
-    R(1:iend,1,2) = factor*b(1:iend)
-    R(1:iend,2,2) = 1.0_jprb - factor*b(1:iend)
+    R(:,1,1) = 1.0_jprb - factor*a(:)
+    R(:,2,1) = factor*a(:)
+    R(:,1,2) = factor*b(:)
+    R(:,2,2) = 1.0_jprb - factor*b(:)
 
     if (lhook) call dr_hook('radiation_matrix:fast_expm_exchange_2',1,hook_handle)
 
@@ -923,30 +1382,33 @@ contains
   ! diagonalization method and is a slight generalization of the
   ! solution provided in the appendix of Hogan et al. (GMD 2018),
   ! which assumed c==d.
-  subroutine fast_expm_exchange_3(n,iend,a,b,c,d,R)
+  subroutine fast_expm_exchange_3(n,a,b,c,d,R)
 
     use yomhook, only : lhook, dr_hook
 
     real(jprb), parameter :: my_epsilon = 1.0e-12_jprb
 
-    integer,                      intent(in)  :: n, iend
+    integer,                      intent(in)  :: n
     real(jprb), dimension(n),     intent(in)  :: a, b, c, d
     real(jprb), dimension(n,3,3), intent(out) :: R
 
     ! Eigenvectors
-    real(jprb), dimension(iend,3,3) :: V
+    real(jprb), dimension(n,3,3) :: V
 
     ! Non-zero Eigenvalues
-    real(jprb), dimension(iend) :: lambda1, lambda2
+    real(jprb), dimension(n) :: lambda1, lambda2
 
     ! Diagonal matrix of the exponential of the eigenvalues
-    real(jprb), dimension(iend,3) :: diag
+    real(jprb), dimension(n,3) :: diag
 
     ! Result of diag right-divided by V
-    real(jprb), dimension(iend,3,3) :: diag_rdivide_V
+    real(jprb), dimension(n,3,3) :: X
 
     ! Intermediate arrays
-    real(jprb), dimension(iend) :: tmp1, tmp2
+    real(jprb), dimension(n) :: y2, y3
+
+    real(jprb), dimension(n) :: L21, L31, L32
+    real(jprb), dimension(n) :: U22, U23, U33
 
     integer :: j1, j2
 
@@ -955,48 +1417,96 @@ contains
     if (lhook) call dr_hook('radiation_matrix:fast_expm_exchange_3',0,hook_handle)
 
     ! Eigenvalues
-    tmp1 = 0.5_jprb * (a(1:iend)+b(1:iend)+c(1:iend)+d(1:iend))
-    tmp2 = sqrt(tmp1*tmp1 - (a(1:iend)*c(1:iend) + a(1:iend)*d(1:iend) + b(1:iend)*d(1:iend)))
-    lambda1 = -tmp1 + tmp2
-    lambda2 = -tmp1 - tmp2
+    y2 = 0.5_jprb * (a(:)+b(:)+c(:)+d(:))
+    y3 = sqrt(y2*y2 - (a(:)*c(:) + a(:)*d(:) + b(:)*d(:)))
+    lambda1 = -y2 + y3
+    lambda2 = -y2 - y3
 
     ! Eigenvectors, with securities such taht if a--d are all zero
     ! then V is non-singular and the identity matrix is returned in R;
     ! note that lambdaX is typically negative so we need a
     ! sign-preserving security
-    V(1:iend,1,1) = max(my_epsilon, b(1:iend)) &
-         &  / sign(max(my_epsilon, abs(a(1:iend) + lambda1)), a(1:iend) + lambda1)
-    V(1:iend,1,2) = b(1:iend) &
-         &  / sign(max(my_epsilon, abs(a(1:iend) + lambda2)), a(1:iend) + lambda2)
-    V(1:iend,1,3) = b(1:iend) / max(my_epsilon, a(1:iend))
-    V(1:iend,2,:) = 1.0_jprb
-    V(1:iend,3,1) = c(1:iend) &
-         &  / sign(max(my_epsilon, abs(d(1:iend) + lambda1)), d(1:iend) + lambda1)
-    V(1:iend,3,2) = c(1:iend) &
-         &  / sign(max(my_epsilon, abs(d(1:iend) + lambda2)), d(1:iend) + lambda2)
-    V(1:iend,3,3) = max(my_epsilon, c(1:iend)) / max(my_epsilon, d(1:iend))
+    V(:,1,1) = max(my_epsilon, b(:)) &
+         &  / sign(max(my_epsilon, abs(a(:) + lambda1)), a(:) + lambda1)
+    V(:,1,2) = b(:) &
+         &  / sign(max(my_epsilon, abs(a(:) + lambda2)), a(:) + lambda2)
+    V(:,1,3) = b(:) / max(my_epsilon, a(:))
+    V(:,2,:) = 1.0_jprb
+    V(:,3,1) = c(:) &
+         &  / sign(max(my_epsilon, abs(d(:) + lambda1)), d(:) + lambda1)
+    V(:,3,2) = c(:) &
+         &  / sign(max(my_epsilon, abs(d(:) + lambda2)), d(:) + lambda2)
+    V(:,3,3) = max(my_epsilon, c(:)) / max(my_epsilon, d(:))
     
     diag(:,1) = exp(lambda1)
     diag(:,2) = exp(lambda2)
     diag(:,3) = 1.0_jprb
 
-    ! Compute diag_rdivide_V = diag * V^-1
-    call diag_mat_right_divide_3(iend,iend,V,diag,diag_rdivide_V)
+    ! ------ Compute X = diag * V^-1 ---------
+    !  call diag_mat_right_divide_3(n,V,diag,X)
 
-    ! Compute V * diag_rdivide_V
+      !    associate (U11 => V(:,1,1), U12 => V(:,1,2), U13 => V(1,3))
+    ! LU decomposition of the *transpose* of V:
+    !       ( 1        )   (U11 U12 U13)
+    ! V^T = (L21  1    ) * (    U22 U23)
+    !       (L31 L32  1)   (        U33)
+    L21 = V(:,1,2) / V(:,1,1)
+    L31 = V(:,1,3) / V(:,1,1)
+    U22 = V(:,2,2) - L21*V(:,2,1)
+    U23 = V(:,3,2) - L21*V(:,3,1)
+    L32 =(V(:,2,3) - L31*V(:,2,1)) / U22
+    U33 = V(:,3,3) - L31*V(:,3,1) - L32*U23
+
+    ! Solve X(1,:) = V^-T ( diag(1) )
+    !                     (  0   )
+    !                     (  0   )
+    ! Solve Ly = diag(:,:,j) by forward substitution
+    ! y1 = diag(:,1)
+    y2 = - L21*diag(:,1)
+    y3 = - L31*diag(:,1) - L32*y2
+    ! Solve UX(:,:,j) = y by back substitution
+    X(:,1,3) = y3 / U33
+    X(:,1,2) = (y2 - U23*X(:,1,3)) / U22
+    X(:,1,1) = (diag(:,1) - V(:,2,1)*X(:,1,2) &
+         &          - V(:,3,1)*X(:,1,3)) / V(:,1,1)
+
+    ! Solve X(2,:) = V^-T (  0   )
+    !                     ( diag(2) )
+    !                     (  0   )
+    ! Solve Ly = diag(:,:,j) by forward substitution
+    ! y1 = 0
+    ! y2 = diag(:,2)
+    y3 = - L32*diag(:,2)
+    ! Solve UX(:,:,j) = y by back substitution
+    X(:,2,3) = y3 / U33
+    X(:,2,2) = (diag(:,2) - U23*X(:,2,3)) / U22
+    X(:,2,1) = (-V(:,2,1)*X(:,2,2) &
+         &           -V(:,3,1)*X(:,2,3)) / V(:,1,1)
+
+    ! Solve X(3,:) = V^-T (  0   )
+    !                     (  0   )
+    !                     ( diag(3) )
+    ! Solve Ly = diag(:,:,j) by forward substitution
+    ! y1 = 0
+    ! y2 = 0
+    ! y3 = diag(:,3)
+    ! Solve UX(:,:,j) = y by back substitution
+    X(:,3,3) = diag(:,3) / U33
+    X(:,3,2) = -U23*X(:,3,3) / U22
+    X(:,3,1) = (-V(:,2,1)*X(:,3,2) &
+         &          - V(:,3,1)*X(:,3,3)) / V(:,1,1)
+
+    ! Compute V * X
     do j1 = 1,3
       do j2 = 1,3
-        R(1:iend,j2,j1) = V(1:iend,j2,1)*diag_rdivide_V(1:iend,1,j1) &
-             &          + V(1:iend,j2,2)*diag_rdivide_V(1:iend,2,j1) &
-             &          + V(1:iend,j2,3)*diag_rdivide_V(1:iend,3,j1)
+        R(:,j2,j1) = V(:,j2,1)*X(:,1,j1) &
+             &          + V(:,j2,2)*X(:,2,j1) &
+             &          + V(:,j2,3)*X(:,3,j1)
       end do
     end do
 
     if (lhook) call dr_hook('radiation_matrix:fast_expm_exchange_3',1,hook_handle)
 
   end subroutine fast_expm_exchange_3
-
-!  generic :: fast_expm_exchange => fast_expm_exchange_2, fast_expm_exchange_3
-
 
 end module radiation_matrix

--- a/radiation/radiation_mcica_sw.F90
+++ b/radiation/radiation_mcica_sw.F90
@@ -51,7 +51,7 @@ contains
     use radiation_cloud, only          : cloud_type
     use radiation_flux, only           : flux_type
     use radiation_two_stream, only     : calc_two_stream_gammas_sw, &
-         &                               calc_reflectance_transmittance_sw
+         &                               calc_reflectance_transmittance_sw_opt
     use radiation_adding_ica_sw, only  : adding_ica_sw
     use radiation_cloud_generator, only: cloud_generator
 
@@ -155,7 +155,7 @@ contains
             call calc_two_stream_gammas_sw(ng, &
                  &  cos_sza, ssa(:,jlev,jcol), g(:,jlev,jcol), &
                  &  gamma1, gamma2, gamma3)
-            call calc_reflectance_transmittance_sw(ng, &
+            call calc_reflectance_transmittance_sw_opt(ng, &
                  &  cos_sza, od(:,jlev,jcol), ssa(:,jlev,jcol), &
                  &  gamma1, gamma2, gamma3, &
                  &  ref_clear(:,jlev), trans_clear(:,jlev), &
@@ -172,7 +172,7 @@ contains
             call calc_two_stream_gammas_sw(ng, &
                  &  cos_sza, ssa_total, g_total, &
                  &  gamma1, gamma2, gamma3)
-            call calc_reflectance_transmittance_sw(ng, &
+            call calc_reflectance_transmittance_sw_opt(ng, &
                  &  cos_sza, od_total, ssa_total, &
                  &  gamma1, gamma2, gamma3, &
                  &  ref_clear(:,jlev), trans_clear(:,jlev), &
@@ -256,7 +256,7 @@ contains
                    &  cos_sza, ssa_total, g_total, &
                    &  gamma1, gamma2, gamma3)
 
-              call calc_reflectance_transmittance_sw(ng, &
+              call calc_reflectance_transmittance_sw_opt(ng, &
                    &  cos_sza, od_total, ssa_total, &
                    &  gamma1, gamma2, gamma3, &
                    &  reflectance(:,jlev), transmittance(:,jlev), &

--- a/radiation/radiation_two_stream.F90
+++ b/radiation/radiation_two_stream.F90
@@ -23,7 +23,7 @@
 
 module radiation_two_stream
 
-  use parkind1, only : jprb, jprd
+  use parkind1, only : jprb
 
   implicit none
   public
@@ -33,7 +33,7 @@ module radiation_two_stream
   ! transmission at all angles through the atmosphere.  Alternatively
   ! think of acos(1/lw_diffusivity) to be the effective zenith angle
   ! of longwave radiation.
-  real(jprd), parameter :: LwDiffusivity = 1.66_jprd
+  real(jprb), parameter :: LwDiffusivity = 1.66_jprb
 
   ! Shortwave diffusivity factor assumes hemispheric isotropy, assumed
   ! by Zdunkowski's scheme and most others; note that for efficiency


### PR DESCRIPTION
Hello,

Here are the performance optimizations I discussed. Most of them target the expm computations in spartacus_sw. In my tests, the solver was about 45% faster (single core on an Intel laptop, ifort -O3). 

Also included in this pull request is a fix to the two-stream kernels which removes the need for any double precision variables/computations by instead adjusting the minimum "k" parameter based on working precision. This change should be tested some more - I only tested the McICA and Spartacus shortwave and longwave solvers and found that net upwelling and downwelling fluxes for the test IFS profiles changed by less than 0.1 W/m2. The benefit is increased performance for single precision computations; 20-25% faster mcica_sw and mcica_lw in my tests. If you want, I can also scrap this and make a pull request for only spartacus_sw.